### PR TITLE
Fix: resolve zizmor auditor persona findings

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -20,16 +20,26 @@ jobs:
   update_release_draft:
     name: 'Update Release Draft'
     permissions:
-      # write permission is required to create releases
-      contents: write
+      contents: write  # Create and update draft releases
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:
-      # Harden the runner used by this workflow
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          egress-policy: 'audit'
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
-      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
+      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e  # v7.5.1

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -18,6 +18,10 @@ on:
       - '!.*'
       - '!tox.ini'
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
@@ -31,6 +35,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: "Build/test node example project 🛠️"
         shell: bash


### PR DESCRIPTION
## Summary

Resolves the zizmor **auditor** persona findings that fail the
organisation's required zizmor gate (`min-severity: low`) and block
Dependabot pull requests from merging.

## Method

- **Boilerplate workflows** (`tag-push`, `release-drafter`,
  `clear-action-cache`, `openssf-scorecard`) that carried findings were
  replaced byte-for-byte with the canonical versions from
  `actions-template`.
- **Repository-specific workflows** (e.g. `testing.yaml`) were adjusted
  in place to match the canonical patterns:
  - added a workflow-level `concurrency` group to match the canonical
    `actions-template` (cancels superseded in-progress runs)
  - added `persist-credentials: false` to checkout steps (resolves the
    zizmor `artipacked` finding)

Verified with `zizmor --persona auditor --min-severity low` (clean) with
no action pin downgrades.
