### PR TITLE
Fix: Patch brace-expansion and js-yaml DoS advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1767,9 +1767,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3579,9 +3579,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -4745,9 +4745,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "jest": "^30.4.2"
   },
   "overrides": {
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.3.0",
+    "brace-expansion": "^2.1.2",
+    "test-exclude": {
+      "brace-expansion": "^1.1.16"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Resolves three high-severity Dependabot alerts affecting transitive
dev dependencies, all via `package.json` `overrides` and a regenerated
lockfile.

| Alert | Package | Advisory | Was | Now |
| ----- | ------- | -------- | --- | --- |
| brace-expansion 2.x | brace-expansion | [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) | 2.1.1 | 2.1.2 |
| brace-expansion 1.x (test-exclude) | brace-expansion | [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) | 1.1.15 | 1.1.16 |
| js-yaml | js-yaml | [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) | 4.2.0 | 4.3.0 |

The `brace-expansion` advisory covers DoS via exponential-time
expansion of consecutive non-expanding `{}` groups. It affects two
separate copies in the tree: the top-level 2.x resolution (vulnerable
`>=2.0.0 <2.1.2`) and the 1.x copy pulled in through `test-exclude`
(vulnerable `<1.1.16`). Both are patched with targeted overrides.

The `js-yaml` advisory covers quadratic CPU consumption via YAML
merge-key chains (vulnerable `>=4.0.0 <4.3.0`). The existing override
is raised from `^4.2.0` to `^4.3.0`.

## Validation

- `npm audit` reports **0 vulnerabilities** (down from 2 high).
- `npm test` passes.
- Commit is DCO signed-off and SSH-signed; pre-commit hooks pass.

All affected packages are `devDependencies`, so runtime behaviour is
unchanged.

Co-authored-by: Claude <claude@anthropic.com>