### PR TITLE
Fix: Patch js-yaml and brace-expansion advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1767,9 +1767,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3579,9 +3579,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -4745,9 +4745,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "jest": "^30.4.2"
   },
   "overrides": {
-    "js-yaml": "^4.3.0",
-    "brace-expansion": "^2.1.2",
+    "js-yaml": "^4.3.1",
+    "brace-expansion": "^2.1.4",
     "test-exclude": {
-      "brace-expansion": "^1.1.16"
+      "brace-expansion": "^1.1.18"
     }
   }
 }


### PR DESCRIPTION
## Summary

Patches three high-severity denial-of-service advisories in transitive dev dependencies. All are fixed by raising existing `overrides` floors — every affected package is reached only through `jest` and cannot be upgraded directly.

| Package | Advisory | Vulnerable | Override |
| --- | --- | --- | --- |
| `js-yaml` | [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) | `>=4.0.0 <4.3.1` | `^4.3.0` → `^4.3.1` |
| `brace-expansion` | [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) | `<1.1.17`, `>=2.0.0 <2.1.3` | `^2.1.2` → `^2.1.4` |
| `brace-expansion` | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) | `<1.1.18`, `>=2.0.0 <2.1.4` | `^1.1.16` → `^1.1.18` (test-exclude) |

## js-yaml — Dependabot alert [#13](https://github.com/lfreleng-actions/test-node-project/security/dependabot/13)

`resolveYamlOmap()` enforced key uniqueness for `!!omap` sequences using a linear `objectKeys.indexOf(...)` scan inside the per-element loop, making resolution **O(n²)** in the number of entries. Because `!!omap` is registered in the *default* schema, a plain `yaml.load(untrustedInput)` is affected with no custom schema or options.

This is the same weakness as CVE-2026-59870 / `GHSA-724g-mxrg-4qvm`, fixed in 5.x at 5.2.1 but never backported. `4.3.1` is the first patched release on the 4.x line.

## brace-expansion

Two DoS advisories — unbounded expansion length causing an OOM crash, and unbounded intermediate arrays that bypass the earlier CVE-2026-14257 mitigation. These **supersede the pins added in 9dc4dc8**: the ranges now cover `<=1.1.17` and `2.0.0 - 2.1.3`, which left both existing overrides (`^2.1.2` and `^1.1.16`) inside the vulnerable ranges.

Two separate override scopes are required, because two different `minimatch` majors are in the tree:

```
jest → @jest/reporters → glob@10 → minimatch@9  → brace-expansion 2.x  (→ 2.1.4)
jest → babel-plugin-istanbul → test-exclude@6 → minimatch@3 → brace-expansion 1.x  (→ 1.1.18)
```

Note that **no Dependabot alert was raised for either**; they surfaced only via `npm audit`.

## Why overrides rather than dependency bumps

`js-yaml` enters the tree solely as a transitive dev dependency:

```
jest@30.4.2 → @jest/core → @jest/transform → babel-plugin-istanbul
  → @istanbuljs/load-nyc-config@1.1.0 → js-yaml
```

`@istanbuljs/load-nyc-config@1.1.0` pins `js-yaml@^3.13.1` and has no newer release, so Dependabot's only path was downgrading `jest` from 30.4.2 to 25.0.0 — an unacceptable regression that the override avoids.

The override forces a 3.x → 4.x major jump on `load-nyc-config`, so I verified API compatibility. It makes exactly one call:

```js
// node_modules/@istanbuljs/load-nyc-config/index.js:80
return require('js-yaml').load(await readFile(configFile, 'utf8'));
```

`load()` is still present in 4.x, so the jump is safe (this override predates this PR and was already in use).

## Verification

- Confirmed 4.3.1 genuinely contains the fix rather than trusting the version string — `lib/type/omap.js` now uses O(1) hash lookups (`_hasOwnProperty.call` + `Object.defineProperty`) in place of the O(n²) `indexOf` scan.
- Resolved tree: `js-yaml@4.3.1`, `brace-expansion@2.1.4`, `brace-expansion@1.1.18`.
- `npm audit` → **found 0 vulnerabilities** (was 1 high).
- `npm test` passes.
- `prek run --all-files` passes.
