### PR TITLE
Fix: Drop the console log from the listen callback

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,4 @@ app.get('/', (req, res) => {
   res.send('Hello World!')
 })
 
-app.listen(port, () => {
-  console.log(`Example app listening on port ${port}`)
-})
+app.listen(port)


### PR DESCRIPTION
Clears the `ai-slop/console-leftover` finding, taking the repository to
a clean aislop score of 100.

## What was wrong

```js
app.listen(port, () => {
  console.log(`Example app listening on port ${port}`)
})
```

The callback existed only to print a startup line.

## The fix

```js
app.listen(port)
```

I considered suppressing this instead, on the grounds that a startup
log in a server entrypoint is legitimate rather than a debug leftover.
Removal won on the specifics: this fixture carries no logging setup, so
`console.log` is the only mechanism available, and nothing consumes the
output — the jest suite covers `sum.js` alone and never starts the
server. Dropping the callback removes the bare console call without
contorting the code around the linter.

## Validation

`aislop ci` reports score 100 with no findings, using the bundled
`ruff` 0.15.4 and `golangci-lint` 2.10.1 that
`aislop-scan-action@v0.2.7` now provisions.

Behaviour is unchanged, verified rather than assumed:

- `node --check app.js` passes.
- `npm test` — 1 suite, 1 test, passing.
- Started the app and issued a request: `GET / -> 200 Hello World!`.

`npm start` continues to work; it simply prints nothing on boot.
